### PR TITLE
Fixed an issue with model parsing

### DIFF
--- a/FDModel/FDModelProvider.m
+++ b/FDModel/FDModelProvider.m
@@ -127,7 +127,7 @@ static FDModelProvider *_sharedInstance;
 		}
 		
 		// If the parent model class did not return a model class ask the block for the model class represented by the dictionary.
-		if (modelClassBlock != nil)
+		if (modelClass != nil && modelClassBlock != nil)
 		{
 			modelClass = modelClassBlock(parentRemoteKeyPath, object);
 		}


### PR DESCRIPTION
Documentation says the model class block is used iff the parent does not provide a class but the parents response was not being checked.

Added a check to only consult the model block if the parent returned `nil`
