### PR TITLE
Fixes a model parse issue CORRECTLY

### DIFF
--- a/FDModel/FDModelProvider.m
+++ b/FDModel/FDModelProvider.m
@@ -127,7 +127,7 @@ static FDModelProvider *_sharedInstance;
 		}
 		
 		// If the parent model class did not return a model class ask the block for the model class represented by the dictionary.
-		if (modelClass != nil && modelClassBlock != nil)
+		if (modelClass == nil && modelClassBlock != nil)
 		{
 			modelClass = modelClassBlock(parentRemoteKeyPath, object);
 		}


### PR DESCRIPTION
Disregard SHA 3424cc9e34a585c729f196d39eb9f0a537af6fb9. Somedays it doesn't pay to get out of bed
