### PR TITLE
Add querying for instance with identifier

### DIFF
--- a/FDModel/FDModel.h
+++ b/FDModel/FDModel.h
@@ -76,6 +76,15 @@ This method uses the shared FDModelProvider instance to attempt to transform the
 + (instancetype)modelWithDictionary: (NSDictionary *)dictionary;
 
 /**
+ Queries the existing instances of this model for an instance with the specified identifier.
+ 
+@param The identifier with which to query for an existing instance.
+ 
+@return Returns either an instance of the model with the specified identifier, or nil if no instance with the identifier exists.
+ */
++ (instancetype)existingModelWithIdentifier: (id)identifier;
+
+/**
 Returns an initialized model with the specified identifier.
 
 This is the designated initializer for this class.

--- a/FDModel/FDModel.m
+++ b/FDModel/FDModel.m
@@ -65,6 +65,21 @@ static NSMutableDictionary *_existingModelsByClass;
 	return model;
 }
 
++ (instancetype)existingModelWithIdentifier: (id)identifier
+{
+	// Synchronized in case the _existingModelsByClass array is mutated on another thread.
+	@synchronized([self class])
+	{
+		NSString *modelClassAsString = NSStringFromClass([self class]);
+		
+		FDCache *existingModels = [_existingModelsByClass objectForKey: modelClassAsString];
+		
+		FDModel *model = [existingModels objectForKey: identifier];
+		
+		return model;
+	}
+}
+
 - (instancetype)initWithIdentifier: (id)identifier 
 	initBlock: (FDModelInitBlock)initBlock 
 	customizationBlock: (FDModelCustomizationBlock)customizationBlock


### PR DESCRIPTION
Added the ability to query existing instances of the model for an instance with the specified identifier so I don't have to use duplicate slug => league mappings
- (instancetype)existingModelWithIdentifier: (id)identifier;
